### PR TITLE
Social User login api v2

### DIFF
--- a/src/main/java/hello/hellospring2/controller/ApiController.java
+++ b/src/main/java/hello/hellospring2/controller/ApiController.java
@@ -1,5 +1,6 @@
 package hello.hellospring2.controller;
 
+import hello.hellospring2.controller.DTO.GuestSignFormDTO;
 import hello.hellospring2.controller.DTO.SignUpFormDTO;
 import hello.hellospring2.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -19,4 +20,14 @@ public class ApiController {
     public ResponseEntity userSignup(@RequestBody SignUpFormDTO formDTO) {
         return memberService.signup(formDTO);
     }
+
+    @PostMapping("/guestsignup")
+    public ResponseEntity GuestuserSignup(@RequestBody GuestSignFormDTO formDTO) {
+        return memberService.guestsignup(formDTO);
+    }
+    @PostMapping("/guestsignout")
+    public ResponseEntity GuestuserSignout(@RequestBody GuestSignFormDTO formDTO) {
+        return memberService.guestsignout(formDTO);
+    }
+
 }

--- a/src/main/java/hello/hellospring2/controller/DTO/GuestSignFormDTO.java
+++ b/src/main/java/hello/hellospring2/controller/DTO/GuestSignFormDTO.java
@@ -1,0 +1,9 @@
+package hello.hellospring2.controller.DTO;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GuestSignFormDTO {
+    private String phoneId;
+}

--- a/src/main/java/hello/hellospring2/domain/Member.java
+++ b/src/main/java/hello/hellospring2/domain/Member.java
@@ -20,9 +20,11 @@ public class Member {
     @Column(name = "member_guid", nullable = false)
     private String guid;
 
+    @Setter
     @Column(name = "member_insta_username", nullable = true)
     private String instaUsername;
 
+    @Setter
     @Column(name = "member_insta_id", nullable = true)
     private String instaId;
 
@@ -31,5 +33,12 @@ public class Member {
 
     @Column(name = "member_phone_id", nullable = true)
     private String phoneId;
+
+    @Column(name = "invalid", nullable = false)
+    private Boolean invalid;
+
+    public void setInvalid(boolean b) {
+        this.invalid=b;
+    }
 
 }

--- a/src/main/java/hello/hellospring2/repository/MemberRepository.java
+++ b/src/main/java/hello/hellospring2/repository/MemberRepository.java
@@ -2,9 +2,13 @@ package hello.hellospring2.repository;
 
 import hello.hellospring2.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, String> {
     Optional<Member> findByInstaId(String name);
+    @Query(value = "SELECT * FROM member WHERE member_phone_id = :phoneId AND invalid = false", nativeQuery = true)
+    Optional<Member> findByPhoneId(@Param("phoneId")String phoneId);
 }

--- a/src/main/java/hello/hellospring2/service/MemberService.java
+++ b/src/main/java/hello/hellospring2/service/MemberService.java
@@ -1,8 +1,11 @@
 package hello.hellospring2.service;
 
+import hello.hellospring2.controller.DTO.GuestSignFormDTO;
 import hello.hellospring2.controller.DTO.SignUpFormDTO;
 import org.springframework.http.ResponseEntity;
 
 public interface MemberService {
     ResponseEntity signup(SignUpFormDTO formDTO);
+    ResponseEntity guestsignup(GuestSignFormDTO formDTO);
+    ResponseEntity guestsignout(GuestSignFormDTO formDTO);
 }

--- a/src/main/java/hello/hellospring2/service/MemberServiceImpl.java
+++ b/src/main/java/hello/hellospring2/service/MemberServiceImpl.java
@@ -1,5 +1,6 @@
 package hello.hellospring2.service;
 
+import hello.hellospring2.controller.DTO.GuestSignFormDTO;
 import hello.hellospring2.controller.DTO.SignUpFormDTO;
 import hello.hellospring2.domain.Member;
 import hello.hellospring2.repository.MemberRepository;
@@ -25,17 +26,63 @@ public class MemberServiceImpl implements MemberService {
         Optional<Member> member = memberRepository.findByInstaId(formDTO.getInstaId());
 
         if (member.isEmpty()) {
+
+            Optional<Member> member2 = memberRepository.findByPhoneId(formDTO.getPhoneId());
+            if (!member2.isEmpty()) {
+                if (formDTO.getInstaUsername()!=null) {
+                    member2.get().setInstaUsername(formDTO.getInstaUsername());
+                    member2.get().setInstaId(formDTO.getInstaId());
+                    memberRepository.save(member2.get());
+                    return ResponseEntity.ok().body(new Result(member2.get(), 1));
+                }
+                return ResponseEntity.ok().body(new Result(member2.get(), 2));
+            }
+
             Member newMember = Member.builder()
                     .instaUsername(formDTO.getInstaUsername())
                     .instaId(formDTO.getInstaId())
                     .phoneId(formDTO.getPhoneId())
                     .guid(UUID.randomUUID().toString())
+                    .invalid(false)
+                    .build();
+
+            if (formDTO.getInstaUsername()!=null) {
+                memberRepository.save(newMember);
+            }
+            return ResponseEntity.ok().body(new Result(newMember, 1));
+        } else {
+            return ResponseEntity.ok().body(new Result(member.get(), 0));
+        }
+    }
+
+    public ResponseEntity<Result> guestsignup(GuestSignFormDTO formDTO) {
+
+        Optional<Member> member = memberRepository.findByPhoneId(formDTO.getPhoneId());
+
+        if (member.isEmpty()) {
+            Member newMember = Member.builder()
+                    .phoneId(formDTO.getPhoneId())
+                    .guid(UUID.randomUUID().toString())
+                    .invalid(false)
                     .build();
 
             memberRepository.save(newMember);
             return ResponseEntity.ok().body(new Result(newMember, 1));
         } else {
             return ResponseEntity.ok().body(new Result(member.get(), 0));
+        }
+    }
+
+    public ResponseEntity<StatusResult> guestsignout(GuestSignFormDTO formDTO) {
+
+        Optional<Member> member = memberRepository.findByPhoneId(formDTO.getPhoneId());
+
+        if (member.isEmpty()) {
+            return ResponseEntity.ok().body(new StatusResult(0));
+        } else {
+            member.get().setInvalid(true);
+            memberRepository.save(member.get());
+            return ResponseEntity.ok().body(new StatusResult(1));
         }
     }
 }
@@ -56,6 +103,16 @@ class Result{
         this.instaUsername = member.getInstaUsername();
         this.instaId = member.getInstaId();
         this.phoneId = member.getPhoneId();
+        this.status = status;
+    }
+}
+
+@Getter
+@Setter
+class StatusResult{
+    private int status;
+
+    public StatusResult(int status){
         this.status = status;
     }
 }


### PR DESCRIPTION
프론트에서 소셜 로그인 API 요청 과정
소셜 회원가입/로그인 버튼 클릭 > https://www.mementross.tech/auth/instagram  > 코드 받음 > GET [https://www.mementross.tech/auth/instagram/callback?code=코드](https://www.mementross.tech/auth/instagram/callback?code=%EC%BD%94%EB%93%9C) > userid 받음
> instaId에 userid, phoneId'만' 담아 POST https://www.mementross.tech/api/signup 요청 > 이미 회원가입 되어있는 경우 기존 정보와 함께 status: 0 반환 , 아닌 경우 1 반환, 비활성화되지 않은 게스트 계정이 존재하는 경우 2 반환
if status=1이 반환된 경우, instagram username 입력 받고 instaId, phoneId, instaUsername(=> 필수)를 담아 다시 한 번 POST https://www.mementross.tech/api/signup 요청 > 회원가입 성공 시 신규 정보와 함께 1 반환
 if status=2가 반환된 경우, instagram username 입력 받고 instaId, phoneId, instaUsername(=> 필수)를 담아 다시 한 번 POST https://www.mementross.tech/api/signup 요청 > 기존 계정 소셜 계정으로 전환 성공 시 기존 정보와 함께 1 반환

프론트에서 게스트 로그인 API 요청 과정
게스트 회원가입/로그인 버튼 클릭 > phoneId와 함께 https://www.mementross.tech/api/guestsignup 요청 > 이미 회원가입 되어 있는 경우 기존 정보와 함께 status: 0 반환, 아닌 경우 회원가입 신규 정보와 함께 1 반환

프론트에서 게스트 로그아웃(계정 삭제) API 요청 과정
> 게스트 로그아웃 버튼 클릭 > phoneId와 함께 https://www.mementross.tech/api/guestsignout 요청 > 해당 레코드 비활성화 후 status: 1 반환, 이미 비활성화되어 있거나 존재하지 않는 경우 status: 0 반환